### PR TITLE
Update Dockerfile to use Go 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN go build -tags netgo -ldflags '-s -w' -o edge
+RUN go build -tags netgo -ldflags '-s -w' -o edgeurid
 
-CMD [ "./edge daemon" ]
+CMD [ "./edgeurid daemon" ]
 EXPOSE 1313

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine
+FROM golang:1.19-alpine
 RUN apk add build-base
 WORKDIR /app
 


### PR DESCRIPTION
Fixes the following build error
```
 => ERROR [8/8] RUN go build -tags netgo -ldflags '-s -w' -o edge                                       47.8s
------
 > [8/8] RUN go build -tags netgo -ldflags '-s -w' -o edge:
#0 1.223 # github.com/quic-go/quic-go/internal/qtls
#0 1.223 /go/pkg/mod/github.com/quic-go/quic-go@v0.33.0/internal/qtls/go_oldversion.go:5:13: cannot use "The version of quic-go you're using can't be built using outdated Go versions. For more details, please see https:/
/github.com/quic-go/quic-go/wiki/quic-go-and-Go-versions." (untyped string constant "The version of quic-go you're using can't be built using outdated Go...) as int value in variable declaration
#0 1.223 note: module requires Go 1.19
#0 1.886 # go.uber.org/multierr
#0 1.886 /go/pkg/mod/go.uber.org/multierr@v1.11.0/error.go:209:20: undefined: atomic.Bool
#0 1.886 note: module requires Go 1.19
#0 7.360 # github.com/libp2p/go-libp2p/p2p/host/eventbus
#0 7.360 /go/pkg/mod/github.com/libp2p/go-libp2p@v0.28.1/p2p/host/eventbus/basic.go:30:23: undefined: atomic.Bool
#0 7.360 /go/pkg/mod/github.com/libp2p/go-libp2p@v0.28.1/p2p/host/eventbus/basic.go:322:23: undefined: atomic.Int32
#0 7.360 /go/pkg/mod/github.com/libp2p/go-libp2p@v0.28.1/p2p/host/eventbus/basic.go:375:19: undefined: atomic.Int32
#0 7.360 /go/pkg/mod/github.com/libp2p/go-libp2p@v0.28.1/p2p/host/eventbus/opts.go:15:19: undefined: atomic.Int64
#0 7.360 note: module requires Go 1.19
------
Dockerfile:11
--------------------
   9 |     COPY . ./
  10 |
  11 | >>> RUN go build -tags netgo -ldflags '-s -w' -o edge
  12 |
  13 |     CMD [ "./edge daemon" ]
--------------------
ERROR: failed to solve: process "/bin/sh -c go build -tags netgo -ldflags '-s -w' -o edge" did not complete successfully: exit code: 2
```